### PR TITLE
.NET Framework 471 architecture added. Version bump to 1.2.3

### DIFF
--- a/DuoUniversal/DuoUniversal.csproj
+++ b/DuoUniversal/DuoUniversal.csproj
@@ -4,9 +4,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <PackageId>DuoUniversal</PackageId>
-    <Version>1.2.2</Version>
+    <Version>1.2.3</Version>
     <Authors>Duo Security</Authors>
     <Company>Duo Security</Company>
     <Copyright>Cisco Systems, Inc. and/or its affiliates</Copyright>
@@ -17,6 +17,7 @@
     <RepositoryType>git</RepositoryType>
     <Description>Duo two-factor authentication for .NET web applications</Description>
     <PackageProjectUrl>https://github.com/duosecurity/duo_universal_csharp</PackageProjectUrl>
+		<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -25,6 +26,10 @@
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
+	<ItemGroup Condition="'$(TargetFramework)' == 'net471'">
+    <Reference Include="System.Web" />
+	</ItemGroup>
+		
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>DuoUniversal.Tests</_Parameter1>


### PR DESCRIPTION
Adding .NET Framework 471 as the TargetFramework to support Duo Epic Hyperdrive